### PR TITLE
Add a serial console to instances

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,7 @@ I have tested ``proxmox-deploy`` with the following *cloud images*:
 +===============+===============+==================================================+
 | Ubuntu        | `14.04`_      | The *-amd64-disk1.img* images work.              |
 |               | `15.10`_      |                                                  |
+|               | `16.04`_      |                                                  |
 +---------------+---------------+--------------------------------------------------+
 | Fedora Server | `23`_         | The *qcow2* image works.                         |
 +---------------+---------------+--------------------------------------------------+
@@ -155,6 +156,7 @@ License
 .. _NoCloud: http://cloudinit.readthedocs.org/en/latest/topics/datasources.html#no-cloud
 .. _14.04: https://cloud-images.ubuntu.com/trusty/current/
 .. _15.10: https://cloud-images.ubuntu.com/wily/current/
+.. _16.04: https://cloud-images.ubuntu.com/xenial/current/
 .. _23: https://getfedora.org/cloud/download/
 .. _13.2: http://download.opensuse.org/repositories/Cloud:/Images:/openSUSE_13.2/images/
 .. _6: http://cloud.centos.org/centos/6/images/

--- a/proxmoxdeploy/cli.py
+++ b/proxmoxdeploy/cli.py
@@ -122,6 +122,8 @@ def main():
                              vmid=proxmox['vmid'],
                              img_file=cloudinit['image'],
                              disk_size=disk_size)
+        logger.info("Adding serial console to VM")
+        api.attach_serial_console(node=proxmox['node'], vmid=proxmox['vmid'])
     except CommandInvocationException as cie:
         logger.error("Provisioning failed")
         if hasattr(cie, "stdout") or hasattr(cie, "stderr"):

--- a/proxmoxdeploy/proxmox.py
+++ b/proxmoxdeploy/proxmox.py
@@ -581,3 +581,17 @@ class ProxmoxClient(object):
         """
         _node = self.client.nodes(node)
         _node.qemu(vmid).status.start.create()
+
+    def attach_serial_console(self, node, vmid):
+        """
+        Adds a serial console
+
+        Parameters
+        ----------
+        node: str
+            Node the VM resides on.
+        vmid: int
+            ID of VM to start.
+        """
+        _node = self.client.nodes(node)
+        _node.qemu(vmid).config.set(serial0="socket")


### PR DESCRIPTION
The ubuntu 16.04 cloud image is not correctly booting without a serial console attached. This adds a serial console to the vm instance. 
